### PR TITLE
Use correct separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,14 +6,14 @@
 # Datatypes (KEYWORD1)
 ###############################################
 
-SCPI_Commands       KEYWORD1    SCPI_Commands
-SCPI_Parameters     KEYWORD1    SCPI_Parameters
-SCPI_Parser         KEYWORD1    SCPI_Parser
+SCPI_Commands	KEYWORD1	SCPI_Commands
+SCPI_Parameters	KEYWORD1	SCPI_Parameters
+SCPI_Parser	KEYWORD1	SCPI_Parser
 
 ###############################################
 # Methods and Functions (KEYWORD2)
 ###############################################
 
-RegisterCommand     KEYWORD2
-Execute             KEYWORD2
-SetCommandTreeBase  KEYWORD2
+RegisterCommand	KEYWORD2
+Execute	KEYWORD2
+SetCommandTreeBase	KEYWORD2


### PR DESCRIPTION
The Arduino IDE currently requires the use of a single true tab separator between the name and identifier. Without this tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords