### PR TITLE
Fix command code assignment for some similar or single-character tokens.

### DIFF
--- a/src/Vrekrer_scpi_parser.h
+++ b/src/Vrekrer_scpi_parser.h
@@ -60,6 +60,7 @@ class SCPI_Parser {
   void ProcessInput(Stream &interface, char* term_chars);
   char* GetMessage(Stream& interface, char* term_chars);
   void PrintDebugInfo();
+  void PrintCommands(Stream& interface);
  protected:
   void AddToken(char* token);
   uint32_t GetCommandCode(SCPI_Commands& commands);


### PR DESCRIPTION
Make the token matching comparisons allow for the possibility of a trailing "?", but actually check that the trailing character is "?", otherwise this can result in false matches to existing tokens, and thus incorrect codes being assigned to commands.

Also added a useful PrintCommands function which exposed the above bug.