### PR TITLE
Refactoring SCPI-Parser

### DIFF
--- a/examples/Ethernet_Shield_V2/Ethernet_Shield_V2.ino
+++ b/examples/Ethernet_Shield_V2/Ethernet_Shield_V2.ino
@@ -1,0 +1,301 @@
+/**
+ * Arduino & Ethernet Shield V2 & DHT-22 Sensor @Vrekrer & Metaln00b
+ * Build with Arduino IDE v1.8.13
+ * Install:
+ * - Ethernet.zip
+ * - Adafruit_Unified_Sensor.zip
+ * - DHT_sensor_library.zip
+ * - Vrekrer_scpi_parser.zip
+ */
+
+#include "Arduino.h"
+#include "EEPROM.h"
+#include <Ethernet.h>
+#include <Adafruit_Sensor.h>
+#include <DHT.h>
+#include <DHT_U.h>
+#include "Vrekrer_scpi_parser.h"
+
+/* DHT 22 */
+#define DHTPIN      5
+#define DHTTYPE     DHT22
+DHT_Unified dht(DHTPIN, DHTTYPE);
+uint32_t delayMS;
+
+/* Ethernet Shield W5500 */
+const int eeprom_eth_data_start = 0;
+byte mac[6] = { 0x74, 0x69, 0x69, 0x2D, 0x30, 0x31 };
+byte ip[4] = {192, 168, 10, 7};
+byte gw[4] = {192, 168, 10, 1};
+byte mask[4] = {255, 255, 255, 0};
+byte dns[4] = {192, 168, 10, 1};
+EthernetServer server = EthernetServer(5025); // SCPI PORT
+
+/* SCPI Parser */
+SCPI_Parser my_instrument;
+
+sensors_event_t event_temp;
+sensors_event_t event_humi;
+
+void setup() {
+    Serial.begin(115200);
+
+    LoadEthernetData();
+    LoadEthernet();
+
+    dht.begin();
+    sensor_t sensor;
+    dht.temperature().getSensor(&sensor);
+    dht.humidity().getSensor(&sensor);
+    delayMS = sensor.min_delay / 1000;
+
+    my_instrument.RegisterCommand(strdup("*IDN?"), &Identify);
+    my_instrument.RegisterCommand(strdup("DHT?"), &GetDHT);
+    my_instrument.SetCommandTreeBase(strdup("SYSTem:COMMunicate:NETWork"));
+        my_instrument.RegisterCommand(strdup(":MAC"), &SetMAC);
+        my_instrument.RegisterCommand(strdup(":MAC?"), &GetMAC);
+        my_instrument.RegisterCommand(strdup(":IP"), &SetIP);
+        my_instrument.RegisterCommand(strdup(":IP?"), &GetIP);
+        my_instrument.RegisterCommand(strdup(":GATeway"), &SetGW);
+        my_instrument.RegisterCommand(strdup(":GATeway?"), &GetGW);
+        my_instrument.RegisterCommand(strdup(":SUBNet"), &SetMASK);
+        my_instrument.RegisterCommand(strdup(":SUBNet?"), &GetMASK);
+        my_instrument.RegisterCommand(strdup(":DNS"), &SetDNS);
+        my_instrument.RegisterCommand(strdup(":DNS?"), &GetDNS);
+
+
+    while (!Serial);
+    my_instrument.PrintDebugInfo();
+}
+
+
+void loop() {
+    char *token = strdup("\r");
+    EthernetClient client;
+    client = server.available();
+    if (client)
+    {
+        my_instrument.ProcessInput(client, token);
+    }
+    free(token);
+
+    dht.temperature().getEvent(&event_temp);
+    dht.humidity().getEvent(&event_humi);
+}
+
+
+/* SCPI FUNCTIONS */
+
+void Identify(SCPI_C commands __attribute__((unused)), SCPI_P parameters __attribute__((unused)), Stream &interface) {
+    interface.println("Vrekrer & Metaln00b, Ethernet Test, P/N: none, S/N: none, HR: 1.0, SR: 1.0.0");
+}
+
+
+void SetMAC(SCPI_C commands __attribute__((unused)), SCPI_P parameters, Stream &interface __attribute__((unused))) {
+    int this_mac[6];
+    int macOk = sscanf(parameters.First(), "%x:%x:%x:%x:%x:%x", &this_mac[0], &this_mac[1], &this_mac[2], &this_mac[3], &this_mac[4], &this_mac[5]);
+
+    int eeprom_address = eeprom_eth_data_start + 1;
+
+    if (macOk == 6)
+    {
+        for (uint8_t i = 0; i < 6; i++)
+        {
+            EEPROM.write(eeprom_address, byte(this_mac[i]));
+            ++eeprom_address;
+        }
+        Serial.println("MAC SAVED");
+        ReloadEthernet();
+    }
+}
+
+
+void GetMAC(SCPI_C commands __attribute__((unused)), SCPI_P parameters __attribute__((unused)), Stream &interface) {
+    byte macBuffer[6];
+    Ethernet.MACAddress(macBuffer);
+
+    for (byte octet = 0; octet < 6; octet++)
+    {
+        interface.print(macBuffer[octet], HEX);
+
+        if (octet < 5)
+        {
+            interface.print(":");
+        }
+    }
+    interface.println("");
+}
+
+
+void SetIP(SCPI_C commands __attribute__((unused)), SCPI_P parameters, Stream &interface __attribute__((unused))) {
+    SaveIP(parameters.First(), eeprom_eth_data_start + 7 );
+}
+
+
+void GetIP(SCPI_C commands __attribute__((unused)), SCPI_P parameters __attribute__((unused)), Stream &interface) {
+    interface.println(Ethernet.localIP());
+}
+
+
+void SetGW(SCPI_C commands __attribute__((unused)), SCPI_P parameters, Stream &interface __attribute__((unused))) {
+    SaveIP(parameters.First(), eeprom_eth_data_start + 11 );
+}
+
+
+void GetGW(SCPI_C commands __attribute__((unused)), SCPI_P parameters __attribute__((unused)), Stream &interface) {
+    interface.println(Ethernet.gatewayIP());
+}
+
+
+void SetMASK(SCPI_C commands __attribute__((unused)), SCPI_P parameters, Stream &interface __attribute__((unused))) {
+    SaveIP(parameters.First(), eeprom_eth_data_start + 15 );
+}
+
+
+void GetMASK(SCPI_C commands __attribute__((unused)), SCPI_P parameters __attribute__((unused)), Stream &interface) {
+    interface.println(Ethernet.subnetMask());
+}
+
+
+void SetDNS(SCPI_C commands __attribute__((unused)), SCPI_P parameters, Stream &interface __attribute__((unused))) {
+    SaveIP(parameters.First(), eeprom_eth_data_start + 19 );
+}
+
+
+void GetDNS(SCPI_C commands __attribute__((unused)), SCPI_P parameters __attribute__((unused)), Stream &interface) {
+    interface.println(Ethernet.dnsServerIP());
+}
+
+
+void GetDHT(SCPI_C commands __attribute__((unused)), SCPI_P parameters __attribute__((unused)), Stream &interface) {
+    if (isnan(event_humi.relative_humidity) || isnan(event_temp.temperature))
+    {
+        interface.println("Error reading temperature and humidity!");
+    }
+    else
+    {
+        interface.print(event_temp.temperature);
+        interface.print(F(", "));
+        interface.println(event_humi.relative_humidity);
+    }
+}
+
+
+/* HELPER FUNCTIONS */
+
+void SaveIP(char* ip_str, int eeprom_address) {
+    int this_ip[4];
+    int ipOk = sscanf(ip_str, "%d.%d.%d.%d", &this_ip[0], &this_ip[1], &this_ip[2], &this_ip[3]);
+    if (ipOk == 4)
+    {
+        for (uint8_t i = 0; i < 4; i++)
+        {
+            EEPROM.write(eeprom_address, byte(this_ip[i]));
+            ++eeprom_address;
+        }
+        Serial.println("IP/GATEWAY/MASK/DNS SAVED");
+        ReloadEthernet();
+    }
+}
+
+
+void LoadEthernetData() {
+    int eeprom_address = eeprom_eth_data_start;
+    if (EEPROM.read(eeprom_address) == 'V') // Already initialized
+    {
+        Serial.println("EEPROM ALREADY INITIALIZED");
+
+        ++eeprom_address;
+        EEPROM.get(eeprom_address, mac);
+        eeprom_address += sizeof(mac);
+        Serial.print("MAC:");
+        for (size_t i = 0; i < sizeof(mac); i++)
+        {
+            Serial.print(mac[i],HEX);
+            if (i != sizeof(mac)-1)
+            {
+                Serial.print(":");
+            }
+        }
+        Serial.println("");
+
+        EEPROM.get(eeprom_address, ip);
+        eeprom_address += sizeof(ip);
+        Serial.print("IP:");
+        for (size_t i = 0; i < sizeof(ip); i++)
+        {
+            Serial.print(ip[i]);
+            if (i != sizeof(ip)-1)
+            {
+                Serial.print(".");
+            }
+        }
+        Serial.println("");
+
+        EEPROM.get(eeprom_address, gw);
+        eeprom_address += sizeof(gw);
+        Serial.print("GATEWAY:");
+        for (size_t i = 0; i < sizeof(gw); i++)
+        {
+            Serial.print(gw[i]);
+            if (i != sizeof(gw)-1)
+            {
+                Serial.print(".");
+            }
+        }
+        Serial.println("");
+
+        EEPROM.get(eeprom_address, mask);
+        eeprom_address += sizeof(mask);
+        Serial.print("MASK:");
+        for (size_t i = 0; i < sizeof(mask); i++)
+        {
+            Serial.print(mask[i]);
+            if (i != sizeof(mask)-1)
+            {
+                Serial.print(".");
+            }
+        }
+        Serial.println("");
+
+        EEPROM.get(eeprom_address, dns);
+        Serial.print("DNS:");
+        for (size_t i = 0; i < sizeof(dns); i++)
+        {
+            Serial.print(dns[i]);
+            if (i != sizeof(dns)-1)
+            {
+                Serial.print(".");
+            }
+        }
+        Serial.println("");
+    }
+    else // Write default values to EEPROM
+    {
+        Serial.println("WRITE EEPROM");
+        EEPROM.write(eeprom_address, 'V');
+        ++eeprom_address;
+        EEPROM.put(eeprom_address, mac);
+        eeprom_address += sizeof(mac);
+        EEPROM.put(eeprom_address, ip);
+        eeprom_address += sizeof(ip);
+        EEPROM.put(eeprom_address, gw);
+        eeprom_address += sizeof(gw);
+        EEPROM.put(eeprom_address, mask);
+        eeprom_address += sizeof(mask);
+        EEPROM.put(eeprom_address, dns);
+    }
+}
+
+
+void LoadEthernet() {
+    Ethernet.begin(mac, ip, dns, gw, mask);
+    server.begin();
+}
+
+
+void ReloadEthernet() {
+    LoadEthernetData();
+    Ethernet.begin(mac, ip, dns, gw, mask);
+    server.begin();
+}

--- a/library.properties
+++ b/library.properties
@@ -1,9 +1,9 @@
 name=Vrekrer SCPI parser
-version=0.2
+version=0.5
 author=Vrekrer
-maintainer=Vrekrer
+maintainer=Vrekrer, Metaln00b
 sentence=Simple SCPI parser
-paragraph=Standar Commands for Programable Instruments (SCPI) parser for small projects
+paragraph=Standard Commands for Programable Instruments (SCPI) parser for small projects
 category=Data Processing
 url=https://github.com/Vrekrer/Vrekrer_scpi_parser
 architectures=*

--- a/src/Vrekrer_scpi_parser.cpp
+++ b/src/Vrekrer_scpi_parser.cpp
@@ -8,43 +8,53 @@ SCPI_String_Array::SCPI_String_Array() {}
 SCPI_String_Array::~SCPI_String_Array() {}
 
 char* SCPI_String_Array::operator[](const uint8_t index) {
-  return values_[index];
+    return values_[index];
 }
 
 void SCPI_String_Array::Append(char* value) {
-  if (size_ < SCPI_ARRAY_SYZE) {
-    values_[size_] = value;
-    size_++;
-  }
+    if (size_ < SCPI_ARRAY_SYZE)
+    {
+        values_[size_] = value;
+        size_++;
+    }
 }
 
 char* SCPI_String_Array::Pop() {
-  if (size_ > 0) {
-    size_--;
-    return values_[size_];
-  } else {
-    return NULL;
-  }
+    if (size_ > 0)
+    {
+        size_--;
+        return values_[size_];
+    }
+    else 
+    {
+        return NULL;
+    }
 }
 
 char* SCPI_String_Array::First() {
-  if (size_ > 0) {
-    return values_[0];
-  } else {
-    return NULL;
-  }
+    if (size_ > 0)
+    {
+        return values_[0];
+    }
+    else
+    {
+        return NULL;
+    }
 }
 
 char* SCPI_String_Array::Last() {
-  if (size_ > 0) {
-    return values_[size_ - 1];
-  } else {
-    return NULL;
-  }
+    if (size_ > 0) 
+    {
+        return values_[size_ - 1];
+    }
+    else
+    {
+        return NULL;
+    }
 }
 
 uint8_t SCPI_String_Array::Size() {
-  return size_;
+    return size_;
 }
 
 // SCPI_Commands member functions
@@ -52,23 +62,27 @@ uint8_t SCPI_String_Array::Size() {
 SCPI_Commands::SCPI_Commands() {}
 
 SCPI_Commands::SCPI_Commands(char *message) {
-  char* token = message;
-  // Trim leading spaces
-  while (isspace(*token)) token++;
-  // Discard parameters and multicommands
-  not_processed_message = strpbrk(token, " \t;");
-  if (not_processed_message != NULL) {
-    not_processed_message += 1;
-    token = strtok(token, " \t;");
-    token = strtok(token, ":");
-  } else {
-    token = strtok(token, ":");
-  }
-  // Strip using ':'
-  while (token != NULL) {
-    this->Append(token);
-    token = strtok(NULL, ":");
-  }
+    char* token = message;
+    // Trim leading spaces
+    while (isspace(*token)) token++;
+    // Discard parameters and multicommands
+    not_processed_message = strpbrk(token, " \t;");
+    if (not_processed_message != NULL)
+    {
+        not_processed_message += 1;
+        token = strtok(token, " \t;");
+        token = strtok(token, ":");
+    }
+    else
+    {
+        token = strtok(token, ":");
+    }
+    // Strip using ':'
+    while (token != NULL)
+    {
+        this->Append(token);
+        token = strtok(NULL, ":");
+    }
 }
 
 // SCPI_Parameters member functions
@@ -76,189 +90,264 @@ SCPI_Commands::SCPI_Commands(char *message) {
 SCPI_Parameters::SCPI_Parameters() {}
 
 SCPI_Parameters::SCPI_Parameters(char* message) {
-  char* parameter = message;
-  // Discard parameters and multicommands
-  not_processed_message = strpbrk(parameter, ";");
-  if (not_processed_message != NULL) {
-    not_processed_message += 1;
-    parameter = strtok(parameter, ";");
-    parameter = strtok(parameter, ",");
-  } else {
-    parameter = strtok(parameter, ",");
-  }
-  // Strip using ':'
-  while (parameter != NULL) {
-    while(isspace(*parameter)) parameter++;
-    this->Append(parameter);
-    parameter = strtok(NULL, ",");
-  }
-  //TODO add support for strings parameters
+    char* parameter = message;
+    // Discard parameters and multicommands
+    not_processed_message = strpbrk(parameter, ";");
+    if (not_processed_message != NULL)
+    {
+        not_processed_message += 1;
+        parameter = strtok(parameter, ";");
+        parameter = strtok(parameter, ",");
+    } 
+    else
+    {
+        parameter = strtok(parameter, ",");
+    }
+    // Strip using ':'
+    while (parameter != NULL)
+    {
+        while(isspace(*parameter))
+        {
+            parameter++;
+        }
+        this->Append(parameter);
+        parameter = strtok(NULL, ",");
+    }
+    //TODO add support for strings parameters
 }
 
 
 //SCPI_Registered_Commands member functions
 
 void SCPI_Parser::AddToken(char *token) {
-  size_t token_size = strlen(token);
-  bool isQuery = (token[token_size - 1] == '?');
-  if (isQuery) token_size--;
+    size_t token_size = strlen(token);
+    bool isQuery = (token[token_size - 1] == '?');
+    if (isQuery)
+    {
+        token_size--;
+    }    
 
-  bool allready_added = false;
-  for (uint8_t i = 0; i < tokens_size_; i++)
-    allready_added ^= (strncmp(token, tokens_[i], token_size) == 0);
-  if (!allready_added) {
-    if (tokens_size_ < SCPI_MAX_TOKENS) {
-      char *stored_token = new char [token_size + 1];
-      strncpy(stored_token, token, token_size);
-      stored_token[token_size] = '\0';
-      tokens_[tokens_size_] = stored_token;
-      tokens_size_++;
+    bool allready_added = false;
+    for (uint8_t i = 0; i < tokens_size_; i++)
+    {
+        allready_added ^= (strncmp(token, tokens_[i], token_size) == 0);
     }
-  }
+    if (!allready_added)
+    {
+        if (tokens_size_ < SCPI_MAX_TOKENS)
+        {
+            char *stored_token = new char [token_size + 1];
+            strncpy(stored_token, token, token_size);
+            stored_token[token_size] = '\0';
+            tokens_[tokens_size_] = stored_token;
+            tokens_size_++;
+        }
+    }
 }
 
 uint32_t SCPI_Parser::GetCommandCode(SCPI_Commands& commands) {
-  uint32_t code = tree_code_ - 1; // tree_code = 1 when execute
-  bool isQuery = false;
-  for (uint8_t i = 0; i < commands.Size(); i++) {
-    code *= SCPI_MAX_TOKENS;
-    size_t header_length = strlen(commands[i]);  //header's length
-    if (i == commands.Size() - 1) { //Last header
-      isQuery = (commands[i][header_length - 1] == '?');
-      if (isQuery) header_length--;
-    }
-    
-    bool isToken;
-    for (uint8_t j = 0; j < tokens_size_; j++) {
-      size_t short_length = 0; //short token's length
-      while (isupper(tokens_[j][short_length])) short_length++;
-      size_t long_length = strlen(tokens_[j]); //long token's length
+    uint32_t code = tree_code_ - 1; // tree_code = 1 when execute
+    bool isQuery = false;
+    for (uint8_t i = 0; i < commands.Size(); i++)
+    {
+        code *= SCPI_MAX_TOKENS;
+        size_t header_length = strlen(commands[i]); //header's length
+        if (i == commands.Size() - 1) //Last header
+        {
+            isQuery = (commands[i][header_length - 1] == '?');
+            if (isQuery) header_length--;
+        }
+        
+        bool isToken;
+        for (uint8_t j = 0; j < tokens_size_; j++)
+        {
+            size_t short_length = 0; //short token's length
+            while (isupper(tokens_[j][short_length]))
+            {
+                short_length++;
+            }
+            size_t long_length = strlen(tokens_[j]); //long token's length
 
-      if ( (tokens_[j][long_length - 1] == '#') //Numeric suffix capable token
-         && (commands[i][header_length - 1] != '#') ) {
-        long_length--;
-        while (isdigit(commands[i][header_length - 1])) header_length--;
-      }
+            if ( (tokens_[j][long_length - 1] == '#') //Numeric suffix capable token
+                && (commands[i][header_length - 1] != '#') )
+            {
+                long_length--;
+                while (isdigit(commands[i][header_length - 1]))
+                {
+                    header_length--;
+                }
+            }
 
-      isToken = true;
-      if (header_length == short_length) { //match with short token
-        for (uint8_t k  = 0; k < short_length; k++)
-          isToken &= (toupper(commands[i][k]) == tokens_[j][k]);
-      } else if (header_length == long_length) { //match with long token
-        for (uint8_t k  = 0; k < long_length; k++)
-          isToken &= (toupper(commands[i][k]) == toupper(tokens_[j][k]));
-      } else {
-        isToken = false;
-      }
-      if (isToken) {
-        code += j;
-        break;
-      }
+            isToken = true;
+            if (header_length == short_length) //match with short token
+            {
+                for (uint8_t k  = 0; k < short_length; k++)
+                {
+                    isToken &= (toupper(commands[i][k]) == tokens_[j][k]);
+                }
+            }
+            else if (header_length == long_length) //match with long token
+            {
+                for (uint8_t k  = 0; k < long_length; k++)
+                {
+                    isToken &= (toupper(commands[i][k]) == toupper(tokens_[j][k]));
+                }
+            }
+            else 
+            {
+                isToken = false;
+            }
+            if (isToken)
+            {
+                code += j;
+                break;
+            }
+        }
+        if (!isToken) 
+        {
+            return 0;
+        }
     }
-    if (!isToken) return 0;
-  }
-  if (isQuery) code ^= 0x80000000;
-  return code+1;
+    if (isQuery)
+    {
+        code ^= 0x80000000;
+    }
+    return code+1;
 }
 
 void SCPI_Parser::SetCommandTreeBase(const __FlashStringHelper* tree_base) {
-  strcpy_P(msg_buffer, (const char *) tree_base);
-  this->SetCommandTreeBase(msg_buffer);
+    strcpy_P(msg_buffer, (const char *) tree_base);
+    this->SetCommandTreeBase(msg_buffer);
 }
 
-void SCPI_Parser::SetCommandTreeBase(const char* tree_base) {
-  if (strlen(tree_base) > 0) {
-    SCPI_Commands tree_tokens(tree_base);
-    for (uint8_t i = 0; i < tree_tokens.Size(); i++)
-      this->AddToken(tree_tokens[i]);
-    tree_code_ = 1;
-    tree_code_ = this->GetCommandCode(tree_tokens);
-  } else {
-    tree_code_ = 1;
-  }
+void SCPI_Parser::SetCommandTreeBase(char* tree_base) {
+    if (strlen(tree_base) > 0)
+    {
+        SCPI_Commands tree_tokens(tree_base);
+        for (uint8_t i = 0; i < tree_tokens.Size(); i++)
+        {
+            this->AddToken(tree_tokens[i]);
+        }
+        tree_code_ = 1;
+        tree_code_ = this->GetCommandCode(tree_tokens);
+    }
+    else
+    {
+        tree_code_ = 1;
+    }
 }
 
 void SCPI_Parser::RegisterCommand(const __FlashStringHelper* command, SCPI_caller_t caller) {
-  strcpy_P(msg_buffer, (const char *) command);
-  this->RegisterCommand(msg_buffer, caller);
+    strcpy_P(msg_buffer, (const char *) command);
+    this->RegisterCommand(msg_buffer, caller);
 }
 
-void SCPI_Parser::RegisterCommand(const char* command, SCPI_caller_t caller) {
-  SCPI_Commands command_tokens(command);
-  for (uint8_t i = 0; i < command_tokens.Size(); i++)
-    this->AddToken(command_tokens[i]);
-  uint32_t code = this->GetCommandCode(command_tokens);
-  valid_codes_[codes_size_] = code;
-  callers_[codes_size_] = caller;
-  codes_size_++;
+void SCPI_Parser::RegisterCommand(char* command, SCPI_caller_t caller) {
+    SCPI_Commands command_tokens(command);
+    for (uint8_t i = 0; i < command_tokens.Size(); i++)
+    {
+        this->AddToken(command_tokens[i]);
+    }
+    uint32_t code = this->GetCommandCode(command_tokens);
+    valid_codes_[codes_size_] = code;
+    callers_[codes_size_] = caller;
+    codes_size_++;
 }
 
-void SCPI_Parser::Execute(char* message, Stream &interface) {
-  tree_code_ = 1;
-  SCPI_Commands commands(message);
-  SCPI_Parameters parameters(commands.not_processed_message);
-  uint32_t code = this->GetCommandCode(commands);
-  for (uint8_t i = 0; i < codes_size_; i++)
-    if (valid_codes_[i] == code)
-      (*callers_[i])(commands, parameters, interface);
+bool SCPI_Parser::Execute(char* message, Stream &interface) {
+    bool result = false;
+    tree_code_ = 1;
+    SCPI_Commands commands(message);
+    SCPI_Parameters parameters(commands.not_processed_message);
+    uint32_t code = this->GetCommandCode(commands);
+    for (uint8_t i = 0; i < codes_size_; i++)
+    {
+        if (valid_codes_[i] == code)
+        {
+            (*callers_[i])(commands, parameters, interface);
+            result = true;
+        }
+    }
+    
+    return result;
 }
 
 char* SCPI_Parser::GetMessage(Stream& interface, char* term_chars) {
-  uint8_t msg_counter = 0;
-  msg_buffer[msg_counter] = '\0';
+    uint8_t msg_counter = 0;
+    msg_buffer[msg_counter] = '\0';
 
-  bool continous_data = false;
-  unsigned long last_data_millis = millis();
-  do {
-    if (interface.available()) {
-        continous_data = true;
-        last_data_millis = millis();
-        msg_buffer[msg_counter] =  interface.read();
+    bool continous_data = false;
+    unsigned long last_data_millis = millis();
+    do
+    {
+        if (interface.available()) {
+            continous_data = true;
+            last_data_millis = millis();
+            msg_buffer[msg_counter] =  interface.read();
 
-        //TODO check msg_counter overflow
-        ++msg_counter;
-        msg_buffer[msg_counter] = '\0';
+            //TODO check msg_counter overflow
+            ++msg_counter;
+            msg_buffer[msg_counter] = '\0';
 
-        if (strstr(msg_buffer, term_chars) != NULL) {
-          msg_buffer[msg_counter - strlen(term_chars)] =  '\0';
-          break;
+            if (strstr(msg_buffer, term_chars) != NULL) {
+                msg_buffer[msg_counter - strlen(term_chars)] =  '\0';
+                break;
+            }
         }
-    } else { //No chars aviable jet
-      if ((millis() - last_data_millis) > 10) // 10 ms without new data
-        continous_data = false;
+        else //No chars available jet
+        {
+            if ((millis() - last_data_millis) > 10) // 10 ms without new data
+            {
+                continous_data = false;
+            }
+        }
+    } while (continous_data);
+    if (continous_data)
+    {
+        return msg_buffer;
     }
-  } while (continous_data);
-  if (continous_data)
-    return msg_buffer;
-  else
-    return NULL;
+    else
+    {
+        return NULL;
+    }
 }
 
 void SCPI_Parser::ProcessInput(Stream& interface, char* term_chars) {
-  char* message = this->GetMessage(interface, term_chars);
-  if (message != NULL) {
-    this->Execute(message, interface);
-  }
+    char* message = this->GetMessage(interface, term_chars);
+    if (message != NULL)
+    {
+        Serial.println(F("*** MESSAGE ***"));
+        Serial.println((message));
+        bool result = this->Execute(message, interface);
+        if (!result)
+        {
+            Serial.println(F("*** ERROR ***"));
+            Serial.println(F("Command not found"));
+            interface.println("Command not found");
+        }
+    }
 }
 
 void SCPI_Parser::PrintDebugInfo() {
-  Serial.println(F("*** DEBUG INFO ***"));
-  Serial.println();
-  Serial.print(F("TOKENS :"));
-  Serial.println(tokens_size_);
-  for (uint8_t i = 0; i < tokens_size_; i++) {
-    Serial.print(F("  "));
-    Serial.println(String(tokens_[i]));
-    Serial.flush();
-  }
-  Serial.println();
-  Serial.println(F("VALID CODES :"));
-  for (uint8_t i = 0; i < codes_size_; i++) {
-    Serial.print(F("  "));
-    Serial.println(valid_codes_[i]);
-    Serial.flush();
-  }
-  Serial.println();
-  Serial.println(F("*******************"));
-  Serial.println();
+    Serial.println(F("*** DEBUG INFO ***"));
+    Serial.println();
+    Serial.print(F("TOKENS :"));
+    Serial.println(tokens_size_);
+    for (uint8_t i = 0; i < tokens_size_; i++)
+    {
+        Serial.print(F("  "));
+        Serial.println(String(tokens_[i]));
+        Serial.flush();
+    }
+    Serial.println();
+    Serial.println(F("VALID CODES :"));
+    for (uint8_t i = 0; i < codes_size_; i++)
+    {
+        Serial.print(F("  "));
+        Serial.println(valid_codes_[i]);
+        Serial.flush();
+    }
+    Serial.println();
+    Serial.println(F("*******************"));
+    Serial.println();
 }

--- a/src/Vrekrer_scpi_parser.h
+++ b/src/Vrekrer_scpi_parser.h
@@ -18,32 +18,32 @@
 #include "Arduino.h"
 
 class SCPI_String_Array {
- public:
-  SCPI_String_Array();
-  ~SCPI_String_Array();
-  char* operator[](const byte index);
-  void Append(char* value);
-  char* Pop();
-  char* First();
-  char* Last();
-  uint8_t Size();
- protected:
-  uint8_t size_ = 0;
-  char* values_[SCPI_ARRAY_SYZE];
+    public:
+        SCPI_String_Array();
+        ~SCPI_String_Array();
+        char* operator[](const byte index);
+        void Append(char* value);
+        char* Pop();
+        char* First();
+        char* Last();
+        uint8_t Size();
+    protected:
+        uint8_t size_ = 0;
+        char* values_[SCPI_ARRAY_SYZE];
 };
 
 class SCPI_Commands : public SCPI_String_Array {
- public:
-  SCPI_Commands();
-  SCPI_Commands(char* message);
-  char* not_processed_message;
+    public:
+        SCPI_Commands();
+        SCPI_Commands(char* message);
+        char* not_processed_message;
 };
 
 class SCPI_Parameters : public SCPI_String_Array {
- public:
-  SCPI_Parameters();
-  SCPI_Parameters(char *message);
-  char* not_processed_message;
+    public:
+        SCPI_Parameters();
+        SCPI_Parameters(char *message);
+        char* not_processed_message;
 };
 
 typedef SCPI_Commands SCPI_C;
@@ -51,25 +51,25 @@ typedef SCPI_Parameters SCPI_P;
 typedef void (*SCPI_caller_t)(SCPI_C, SCPI_P, Stream&);
 
 class SCPI_Parser {
- public:
-  void SetCommandTreeBase(const char* tree_base);
-  void SetCommandTreeBase(const __FlashStringHelper* tree_base);
-  void RegisterCommand(const char* command, SCPI_caller_t caller);
-  void RegisterCommand(const __FlashStringHelper* command, SCPI_caller_t caller);
-  void Execute(char* message, Stream& interface);
-  void ProcessInput(Stream &interface, char* term_chars);
-  char* GetMessage(Stream& interface, char* term_chars);
-  void PrintDebugInfo();
- protected:
-  void AddToken(char* token);
-  uint32_t GetCommandCode(SCPI_Commands& commands);
-  uint8_t tokens_size_ = 0;
-  char *tokens_[SCPI_MAX_TOKENS];
-  uint8_t codes_size_ = 0;
-  uint32_t valid_codes_[SCPI_MAX_COMMANDS];
-  SCPI_caller_t callers_[SCPI_MAX_COMMANDS];
-  uint32_t tree_code_ = 1;
-  char msg_buffer[64]; //TODO BUFFER_LENGTH
+    public:
+        void SetCommandTreeBase(char* tree_base);
+        void SetCommandTreeBase(const __FlashStringHelper* tree_base);
+        void RegisterCommand(char* command, SCPI_caller_t caller);
+        void RegisterCommand(const __FlashStringHelper* command, SCPI_caller_t caller);
+        bool Execute(char* message, Stream& interface);
+        void ProcessInput(Stream &interface, char* term_chars);
+        char* GetMessage(Stream& interface, char* term_chars);
+        void PrintDebugInfo();
+    protected:
+        void AddToken(char* token);
+        uint32_t GetCommandCode(SCPI_Commands& commands);
+        uint8_t tokens_size_ = 0;
+        char *tokens_[SCPI_MAX_TOKENS];
+        uint8_t codes_size_ = 0;
+        uint32_t valid_codes_[SCPI_MAX_COMMANDS];
+        SCPI_caller_t callers_[SCPI_MAX_COMMANDS];
+        uint32_t tree_code_ = 1;
+        char msg_buffer[64]; //TODO BUFFER_LENGTH
 };
 
-#endif 
+#endif


### PR DESCRIPTION
- Adding example using an ethernet shield v2 (W5500) in combination with
a DHT-22 temperature and humidity sensor
- Removing compiler warnings
- Clean up library code
- Using serial interface as debug interface
- Now responds to non-existing commands
- Token changed to '\r', because of '\r\n'
- Works with puTTY telnet (Implicit CR in every LF, Telnet negotation
mode Passive)
- Works with labVIEW (Stop reading after linefeed and remove CRLF)