### PR TITLE
Update Vrekrer_scpi_parser.h

### DIFF
--- a/src/Vrekrer_scpi_parser.h
+++ b/src/Vrekrer_scpi_parser.h
@@ -72,6 +72,7 @@ class SCPI_Parser {
   void PrintDebugInfo();
   bool buffer_overflow = false;
   bool timeout = false;
+  bool unknownCommand = false;
  protected:
   void AddToken(char* token);
   uint32_t GetCommandCode(SCPI_Commands& commands);


### PR DESCRIPTION
class SCPI_Parser: add  public attribute "unknownCommand" (to indicate a unknown Command, so with the use of the Execute method you can handle unknown Comands e.g. from Serial now)