### PR TITLE
Use std::function

### DIFF
--- a/src/Vrekrer_scpi_parser.cpp
+++ b/src/Vrekrer_scpi_parser.cpp
@@ -351,14 +351,14 @@ void SCPI_Parser::Execute(char* message, Stream &interface) {
     uint8_t i;
     for (i = 0; i < codes_size_; i++)
       if (valid_codes_[i] == code) {
-        (*callers_[i])(commands, parameters, interface);
+        callers_[i](commands, parameters, interface);
         break;
       }
     if (i==codes_size_) {
       //code not found in valid_codes_
       //Call ErrorHandler UnknownCommand
       last_error = ErrorCode::UnknownCommand;
-      (*callers_[max_commands])(commands, parameters, interface);
+      callers_[max_commands](commands, parameters, interface);
     }
     message = multicomands;
   }
@@ -399,7 +399,7 @@ char* SCPI_Parser::GetMessage(Stream& interface, const char* term_chars) {
     if (message_length_ >= buffer_length){
       //Call ErrorHandler due BufferOverflow
       last_error = ErrorCode::BufferOverflow;
-      (*callers_[max_commands])(SCPI_C(), SCPI_P(), interface);
+      callers_[max_commands](SCPI_C(), SCPI_P(), interface);
       message_length_ = 0;
       return NULL;
     }
@@ -422,7 +422,7 @@ char* SCPI_Parser::GetMessage(Stream& interface, const char* term_chars) {
   if ((millis() - time_checker_) > timeout) {
       //Call ErrorHandler due Timeout
       last_error = ErrorCode::Timeout;
-      (*callers_[max_commands])(SCPI_C(), SCPI_P(), interface);
+      callers_[max_commands](SCPI_C(), SCPI_P(), interface);
       message_length_ = 0;
       return NULL;
   }

--- a/src/Vrekrer_scpi_parser.h
+++ b/src/Vrekrer_scpi_parser.h
@@ -91,7 +91,7 @@ typedef SCPI_Commands SCPI_C;
 typedef SCPI_Parameters SCPI_P;
 
 ///Void template used with SCPI_Parser::RegisterCommand.
-typedef void (*SCPI_caller_t)(SCPI_Commands, SCPI_Parameters, Stream&);
+using SCPI_caller_t = std::function<void(SCPI_C commands, SCPI_P parameters, Stream &interface)>;
 
 /// Integer size used for hashes.
 typedef SCPI_HASH_TYPE scpi_hash_t;


### PR DESCRIPTION
Using std::function allows callbacks to be passed as lambda functions and thus avoids polluting the global scope.

This is fully backwards compatible with existing code.