### PR TITLE
Const member function to improve performance

### DIFF
--- a/src/Vrekrer_scpi_arrays_code.h
+++ b/src/Vrekrer_scpi_arrays_code.h
@@ -5,7 +5,7 @@
 // ## SCPI_String_Array member functions ##
 
 ///Add indexing capability.
-char* SCPI_String_Array::operator[](const uint8_t index) {
+char* SCPI_String_Array::operator[](const uint8_t index) const {
   if (index >= size_) return NULL; //Invalid index
   return values_[index];
 }
@@ -26,19 +26,19 @@ char* SCPI_String_Array::Pop() {
 }
 
 ///Returns the first element of the array
-char* SCPI_String_Array::First() {
+char* SCPI_String_Array::First() const {
   if (size_ == 0) return NULL; //Empty array
   return values_[0];
 }
 
 ///Returns the last element of the array
-char* SCPI_String_Array::Last() {
+char* SCPI_String_Array::Last() const {
   if (size_ == 0) return NULL; //Empty array
   return values_[size_ - 1];
 }
 
 ///Array size
-uint8_t SCPI_String_Array::Size() {
+uint8_t SCPI_String_Array::Size() const {
   return size_;
 }
 

--- a/src/Vrekrer_scpi_parser.h
+++ b/src/Vrekrer_scpi_parser.h
@@ -56,12 +56,12 @@ Header file.
 */
 class SCPI_String_Array {
  public:
-  char* operator[](const byte index);  //Add indexing capability
+  char* operator[](const byte index) const;  //Add indexing capability
   void Append(char* value);            //Append new string (LIFO stack Push)
   char* Pop();                         //LIFO stack Pop
-  char* First();                       //Returns the first element of the array
-  char* Last();                        //Returns the last element of the array
-  uint8_t Size();                      //Array size
+  char* First() const;                       //Returns the first element of the array
+  char* Last() const;                        //Returns the last element of the array
+  uint8_t Size() const;                      //Array size
   bool overflow_error = false;         //Storage overflow error
   const uint8_t storage_size = SCPI_ARRAY_SYZE; //Max size of the array 
  protected:
@@ -104,7 +104,7 @@ using SCPI_C = SCPI_Commands;
 using SCPI_P = SCPI_Parameters;
 
 ///Void template used with SCPI_Parser::RegisterCommand.
-using SCPI_caller_t = void(*)(SCPI_Commands, SCPI_Parameters, Stream&); 
+using SCPI_caller_t = void(*)(SCPI_Commands, SCPI_Parameters, Stream&);
 ///Void template used with SCPI_Parser::RegisterSpecialCommand.
 using SCPI_special_caller_t = void(*)(SCPI_Commands, Stream&);
 


### PR DESCRIPTION
The C++ compiler can work harder if it knows that operator[] does not alter the states. At compiler optimization level 3, the generated AVR assembly has ~5% to 10% reduction in size.