### PR TITLE
Fixed inverted VREKRER_SCPI_PARSER_NO_IMPL in Vrekrer_scpi_parser.h

### DIFF
--- a/src/Vrekrer_scpi_parser.h
+++ b/src/Vrekrer_scpi_parser.h
@@ -245,7 +245,7 @@ class SCPI_Parser {
 //
 // (.text+0x0): multiple definition of `SCPI_Parser::ProcessInput(Stream&, char const*)'
 
-#ifdef VREKRER_SCPI_PARSER_NO_IMPL
+#ifndef VREKRER_SCPI_PARSER_NO_IMPL
 #include "Vrekrer_scpi_arrays_code.h"
 #include "Vrekrer_scpi_parser_code.h"
 #include "Vrekrer_scpi_parser_special_code.h"


### PR DESCRIPTION
Fixed inverted ifdef for VREKRER_SCPI_PARSER_NO_IMPL.