### PR TITLE
Fix potential memory leak

### DIFF
--- a/src/Vrekrer_scpi_parser.h
+++ b/src/Vrekrer_scpi_parser.h
@@ -201,6 +201,8 @@ class SCPI_Parser {
   scpi_hash_t GetCommandCode_(SCPI_Commands& commands);
   //Number of stored tokens
   uint8_t tokens_size_ = 0;
+  //Static storage for tokens (eliminates heap allocation)
+  char tokens_storage_[SCPI_MAX_TOKENS][SCPI_BUFFER_LENGTH];
   //Storage for tokens
   char *tokens_[SCPI_MAX_TOKENS];
   //Number of registered commands

--- a/src/Vrekrer_scpi_parser_code.h
+++ b/src/Vrekrer_scpi_parser_code.h
@@ -32,10 +32,9 @@ void SCPI_Parser::AddToken_(char *token) {
     //Check if the token is allready added
     if ( (strncmp(token, tokens_[i], token_size) == 0) 
           and (token_size == strlen(tokens_[i])) ) return;
-  char *stored_token = new char [token_size + 1];
-  strncpy(stored_token, token, token_size);
-  stored_token[token_size] = '\0';
-  tokens_[tokens_size_] = stored_token;
+  strncpy(tokens_storage_[tokens_size_], token, token_size);
+  tokens_storage_[tokens_size_][token_size] = '\0';
+  tokens_[tokens_size_] = tokens_storage_[tokens_size_];
   tokens_size_++;
 }
 


### PR DESCRIPTION
## Description
Fixed potential memory leak in `AddToken_()` function where dynamic allocation with `new char[]` was never freed.

## Changes
- Replace heap allocation (`new char[]`) with static buffer in class storage
- Eliminates memory leak on Arduino devices with limited RAM
- No functional changes to the API