### PR TITLE
Add bounds checking to prevent buffer overflow

### DIFF
--- a/src/Vrekrer_scpi_parser_code.h
+++ b/src/Vrekrer_scpi_parser_code.h
@@ -144,7 +144,13 @@ void SCPI_Parser::SetCommandTreeBase(char* tree_base) {
  For lower RAM usage use the Flash strings version.
 */
 void SCPI_Parser::SetCommandTreeBase(const char* tree_base) {
-  strcpy(msg_buffer_, tree_base);
+  size_t len = strlen(tree_base);
+  if (len >= buffer_length) {
+    setup_errors.command_overflow = true;
+    return;
+  }
+  strncpy(msg_buffer_, tree_base, buffer_length - 1);
+  msg_buffer_[buffer_length - 1] = '\0';
   this->SetCommandTreeBase(msg_buffer_);
 }
 
@@ -195,7 +201,13 @@ void SCPI_Parser::RegisterCommand(char* command, SCPI_caller_t caller) {
  For lower RAM usage use the Flash strings version.
 */
 void SCPI_Parser::RegisterCommand(const char* command, SCPI_caller_t caller) {
-  strcpy(msg_buffer_, command);
+  size_t len = strlen(command);
+  if (len >= buffer_length) {
+    setup_errors.command_overflow = true;
+    return;
+  }
+  strncpy(msg_buffer_, command, buffer_length - 1);
+  msg_buffer_[buffer_length - 1] = '\0';
   this->RegisterCommand(msg_buffer_, caller);
 }
 


### PR DESCRIPTION
## Description
Added length validation before copying strings to prevent buffer overflow when input exceeds SCPI_BUFFER_LENGTH.

## Changes
- Added bounds checking in `SetCommandTreeBase(const char*)`
- Added bounds checking in `RegisterCommand(const char*, ...)`
- Set `command_overflow` error flag when buffer would overflow
- Use `strncpy` instead of `strcpy` for safety